### PR TITLE
Use bg-<color> class instead of badge-<color>

### DIFF
--- a/templates/configuration.html.twig
+++ b/templates/configuration.html.twig
@@ -9,7 +9,7 @@
         <p>Bolt has detected one or more configuration issues. You should resolve these, for optimum performance:</p>
 
         {% for result in results.notices %}
-            <p><span class="badge badge-{{ result.severity }}">{{ result.severity|ucwords }}</span> - {{ result.notice|raw }}
+            <p><span class="badge bg-{{ result.severity }}">{{ result.severity|ucwords }}</span> - {{ result.notice|raw }}
             {% if result.info %}</p>
             <small style="padding-top: 0.5rem; display: block;">{{ result.info|raw }}</small>
             {% endif %}

--- a/templates/configuration.html.twig
+++ b/templates/configuration.html.twig
@@ -9,7 +9,8 @@
         <p>Bolt has detected one or more configuration issues. You should resolve these, for optimum performance:</p>
 
         {% for result in results.notices %}
-            <p><span class="badge bg-{{ result.severity }}">{{ result.severity|ucwords }}</span> - {{ result.notice|raw }}
+            <p><span class="badge bg-{{ result.severity }} badge-{{ result.severity }}">{{ result.severity|ucwords }}</span> - {{ result.notice|raw }}
+            {# Note: `badge-{{ result.severity }}` can be removed after the Bootstrap 5 update is complete #}
             {% if result.info %}</p>
             <small style="padding-top: 0.5rem; display: block;">{{ result.info|raw }}</small>
             {% endif %}


### PR DESCRIPTION
In Bootstrap 5 background status colors are no longer set using `badge-warning` or `badge-info` for instance. 

The background must be set using bg-<color> syntax see https://getbootstrap.com/docs/5.0/migration/#badges

This change should be merged and released at the same time Bootstrap upgrade is released https://github.com/bolt/core/tree/upgrade/bootstrap-v5